### PR TITLE
fix(#16): lottieのアニメーションが初回ロード時でも再生されるようにした

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import LottieView from 'lottie-react-native';
-import { FC } from 'react';
+import { FC, useEffect, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 const styles = StyleSheet.create({
@@ -13,11 +13,22 @@ const styles = StyleSheet.create({
 });
 
 const App: FC = () => {
+  const lottieRef = useRef<LottieView>(null);
+
+  useEffect(() => {
+    if (lottieRef.current) {
+      setTimeout(() => {
+        lottieRef.current?.reset();
+        lottieRef.current?.play();
+      }, 100);
+    }
+  }, [lottieRef.current]);
+
   return (
     <View style={styles.container}>
       <LottieView
+        ref={lottieRef}
         source={require('./assets/lottie/lottie_box_ani.json')}
-        autoPlay
         loop
         style={{
           height: 90,


### PR DESCRIPTION
## チケット

#16

## 実装内容

Lottieのアニメーションが初回ロード時に再生されないのを修正した。

## レビュー観点


## 変更の種類

- バグ修正

## その他

参照元：https://github.com/lottie-react-native/lottie-react-native/issues/832#issuecomment-1008209732
